### PR TITLE
fix(infra): Add missing pod scheduling fields to StatefulSet template

### DIFF
--- a/charts/vespa/CHANGELOG.md
+++ b/charts/vespa/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.24](https://github.com/onyx-dot-app/vespa-helm-charts/compare/vespa-0.2.23...vespa-0.2.24) (2025-08-06)
+
+### Bug Fixes
+
+* Add missing pod scheduling fields to StatefulSet template ([#PR_NUMBER](https://github.com/onyx-dot-app/vespa-helm-charts/pull/PR_NUMBER))
+  * Add `nodeSelector` support for node selection
+  * Add `affinity` support for advanced scheduling rules  
+  * Add `tolerations` support for taint toleration
+  * This enables proper pod scheduling configuration through Helm values, which is essential for production deployments with dedicated nodes and taints
+
 ## [0.2.21](https://github.com/onyx-dot-app/vespa-helm-charts/compare/vespa-0.2.18...vespa-v0.2.16) (2024-12-10)
 
 * Update default memory to 4GB and storage to 8GB per Vespa recommended settings.

--- a/charts/vespa/Chart.yaml
+++ b/charts/vespa/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.23
+version: 0.2.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/vespa/templates/statefulset.yaml
+++ b/charts/vespa/templates/statefulset.yaml
@@ -28,6 +28,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "vespa.serviceAccountName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:


### PR DESCRIPTION
## Fix: Add missing pod scheduling fields to StatefulSet template

### Problem
The Vespa Helm chart defines `tolerations`, `nodeSelector`, and `affinity` in values.yaml but doesn't implement them in the StatefulSet template. This prevents users from configuring pod scheduling behavior through Helm values, which is essential for production deployments with dedicated nodes and taints.

### Solution
Added the missing fields to the pod spec in the StatefulSet template:
- `nodeSelector`: For node selection
- `affinity`: For advanced scheduling rules  
- `tolerations`: For taint toleration

### Changes Made
1. **Updated `charts/vespa/templates/statefulset.yaml`**:
   - Added `nodeSelector` support
   - Added `affinity` support
   - Added `tolerations` support

2. **Bumped version to `0.2.24`** in `Chart.yaml`

3. **Updated `CHANGELOG.md`** with detailed description

### Testing
- ✅ Tolerations properly applied to StatefulSet pods
- ✅ NodeSelector properly applied to StatefulSet pods  
- ✅ Affinity properly applied to StatefulSet pods

### Impact
This enables proper pod scheduling configuration through Helm values, which is essential for:
- Production deployments with dedicated nodes
- Taint-based node isolation
- Advanced scheduling requirements
- Compliance with Kubernetes best practices

### Backward Compatibility
- ✅ Existing deployments continue to work unchanged
- ✅ Default values remain the same (`nodeSelector: {}`, `tolerations: []`, `affinity: {}`)
- ✅ No breaking changes

### Example Usage
```yaml
vespa:
  tolerations:
    - key: "vespa-dedicated"
      operator: "Equal"
      value: "true"
      effect: "NoSchedule"
  nodeSelector:
    kubernetes.io/os: linux
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux
```

This fix resolves a critical gap in the Helm chart's functionality and makes it production-ready for deployments requiring advanced pod scheduling configuration.